### PR TITLE
Fix insecure script warning

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -113,7 +113,7 @@
 </head>
 
 <body onload="init();">
-<script src="http://code.createjs.com/soundjs-0.5.2.min.js"></script>
+<script src="https://code.createjs.com/soundjs-0.5.2.min.js"></script>
 
 	<div id="loader"></div>
 


### PR DESCRIPTION
Chrome and probably other web browsers are blocking the soundjs library from being loaded as it's being requested over HTTP when the site is being served on GitHub pages via https.

Requesting the library via https will fix it

fixes #1 